### PR TITLE
Update `ci.yml`: flakehub cache action rather than deprecated version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@main
       - name: Nix cache
-        uses: DeterminateSystems/magic-nix-cache-action@main
+        uses: DeterminateSystems/flakehub-cache-action@main
       - name: Install packages
         run: uv sync
       - name: Check lint


### PR DESCRIPTION
Minor chore. 

the cache action (that makes our gh action run way faster) is being deprecated, this boosts it to the current. 